### PR TITLE
ROCANA-5453: Add metadata required by central artifacts to rocana-configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,35 @@
   <artifactId>rocana-configuration</artifactId>
   <version>1.2.0-SNAPSHOT</version>
 
+  <name>Rocana Configuration</name>
+  <description>
+    A JSON-like configuration format that doesn't require quoting key names in dictionaries
+    and supports richer types including floats, doubles, data sizes, and durations.
+  </description>
+  <url>https://github.com/scalingdata/rocana-configuration</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Eric Sammer</name>
+      <email>esammer@rocana.com</email>
+      <organization>Rocana</organization>
+      <organizationUrl>http://www.rocana.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Joey Echeverria</name>
+      <email>joey@rocana.com</email>
+      <organization>Rocana</organization>
+      <organizationUrl>http://www.rocana.com</organizationUrl>
+    </developer>
+  </developers>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -165,19 +194,6 @@
     </dependency>
 
   </dependencies>
-
-  <distributionManagement>
-    <repository>
-      <id>com.rocana.releases</id>
-      <name>Rocana Release Repository</name>
-      <url>http://repository.rocana.com/content/repositories/com.scalingdata.releases/</url>
-    </repository>
-    <snapshotRepository>
-      <id>com.rocana.snapshots</id>
-      <name>Rocana Snapshots Repository</name>
-      <url>http://repository.rocana.com/content/repositories/com.scalingdata.snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <scm>
     <connection>scm:git:git@github.com:scalingdata/rocana-configuration.git</connection>


### PR DESCRIPTION
- Added required name, description, url, licenses, and developers tags.
- Removed repositories as we'll hopefully be moving to Sonatype OSSRH soon.
