### PR TITLE
ROCANA-3437: Rocana configuration should support Double values

### DIFF
--- a/src/main/antlr4/com/rocana/configuration/antlr/Configuration.g4
+++ b/src/main/antlr4/com/rocana/configuration/antlr/Configuration.g4
@@ -45,6 +45,7 @@ value: value_variable |
   value_duration |
   value_long |
   value_float |
+  value_double |
   value_int |
   value_string |
   value_boolean |
@@ -58,6 +59,7 @@ value_size: SIZE # ValueSize;
 value_duration: (DURATION_ISO8601 | DURATION_SIMPLE) # ValueDuration;
 value_long: LONG # ValueLong;
 value_float: FLOAT # ValueFloat;
+value_double: DOUBLE # ValueDouble;
 value_int: INT # ValueInteger;
 value_string: QUOTED_STRING # ValueString;
 value_variable: VARIABLE # ValueVariable;
@@ -97,6 +99,7 @@ BRACE_RIGHT: '}';
  */
 LONG: '-'? DIGITS 'L';
 FLOAT: '-'? DIGITS ((DOT DIGITS) 'F'? | 'F');
+DOUBLE: '-'? DIGITS ((DOT DIGITS) 'D' | 'D');
 DURATION_ISO8601: 'P' (
   (FLOAT_IMPLICIT 'Y' FLOAT_IMPLICIT 'M' FLOAT_IMPLICIT 'D' DURATION_TIME_ISO8601) |
   (FLOAT_IMPLICIT 'Y' FLOAT_IMPLICIT 'M' FLOAT_IMPLICIT 'D') |

--- a/src/main/java/com/rocana/configuration/ConfigurationParser.java
+++ b/src/main/java/com/rocana/configuration/ConfigurationParser.java
@@ -104,6 +104,7 @@ public class ConfigurationParser {
     private static final Set<String> booleanTrueValues = Sets.newHashSet("true", "on", "enabled", "yes");
     private static final Pattern patternLong = Pattern.compile("^(\\d+)(?:\\s*[lL])?$");
     private static final Pattern patternFloat = Pattern.compile("^(\\d+(?:\\.\\d+)?)(?:\\s*[fF])?$");
+    private static final Pattern patternDouble = Pattern.compile("^(\\d+(?:\\.\\d+)?)(?:\\s*[dD])?$");
     private static final PeriodParser DURATION_PARSER_ISO8601 = new PeriodFormatterBuilder()
       .appendLiteral("P")
       .appendYears().appendSuffix("Y")
@@ -174,6 +175,17 @@ public class ConfigurationParser {
       }
 
       return Lists.<Object>newArrayList(Float.parseFloat(matcher.group(1)));
+    }
+
+    @Override
+    public List<Object> visitValueDouble(com.rocana.configuration.antlr.ConfigurationParser.ValueDoubleContext ctx) {
+      Matcher matcher = patternDouble.matcher(ctx.DOUBLE().getText());
+
+      if (!matcher.matches()) {
+        throw new ConfigurationException("Double value " + ctx.DOUBLE().getText() + " can not be parsed");
+      }
+
+      return Lists.<Object>newArrayList(Double.parseDouble(matcher.group(1)));
     }
 
     @Override

--- a/src/test/java/com/rocana/configuration/FlatObject.java
+++ b/src/test/java/com/rocana/configuration/FlatObject.java
@@ -30,6 +30,7 @@ class FlatObject {
   private String stringValue;
   private Long longValue;
   private Float floatValue;
+  private Double doubleValue;
   private String sizeValue;
   private Period durationValue;
   private EmptyObject objectValue;
@@ -88,6 +89,15 @@ class FlatObject {
     this.floatValue = floatValue;
   }
 
+  public Double getDoubleValue() {
+    return doubleValue;
+  }
+
+  @ConfigurationProperty(name = "double-value")
+  public void setDoubleValue(Double doubleValue) {
+    this.doubleValue = doubleValue;
+  }
+
   public String getSizeValue() {
     return sizeValue;
   }
@@ -124,6 +134,7 @@ class FlatObject {
       .add("stringValue", stringValue)
       .add("longValue", longValue)
       .add("floatValue", floatValue)
+      .add("doubleValue", doubleValue)
       .add("sizeValue", sizeValue)
       .add("durationValue", durationValue)
       .add("objectValue", objectValue)

--- a/src/test/java/com/rocana/configuration/TestTypeMapping.java
+++ b/src/test/java/com/rocana/configuration/TestTypeMapping.java
@@ -35,7 +35,7 @@ public class TestTypeMapping {
 
     List<TypeDescriptor> children = typeDescriptor.getChildren();
 
-    Assert.assertEquals(9, children.size());
+    Assert.assertEquals(10, children.size());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class TestTypeMapping {
 
     Assert.assertEquals(true, flatObjectDescriptor.hasChildren());
     Assert.assertEquals(FlatObject.class, flatObjectDescriptor.getTargetType());
-    Assert.assertEquals(9, flatObjectDescriptor.getChildren().size());
+    Assert.assertEquals(10, flatObjectDescriptor.getChildren().size());
   }
 
   @Test
@@ -128,7 +128,7 @@ public class TestTypeMapping {
 
     Assert.assertEquals(true, flatObjectDescriptor.hasChildren());
     Assert.assertEquals(FlatObject.class, flatObjectDescriptor.getTargetType());
-    Assert.assertEquals(9, flatObjectDescriptor.getChildren().size());
+    Assert.assertEquals(10, flatObjectDescriptor.getChildren().size());
   }
 
   @Test

--- a/src/test/resources/conf/double-requires-type.conf
+++ b/src/test/resources/conf/double-requires-type.conf
@@ -19,8 +19,8 @@
   boolean-value: true,
   string-value: "Hello world",
   long-value: 1L,
-  float-value: 1F,
-  double-value: 1D,
+  float-value: 1.0,
+  double-value: 1.0,
   size-value: 1 GB,
   duration-value: 1 minute,
   object-value: { }


### PR DESCRIPTION
This is a re-submission of PR https://github.com/scalingdata/rocana-configuration/pull/12 rebased on master and updated based on the discussion there.